### PR TITLE
fix: Make sure the decoder options isn't freed

### DIFF
--- a/src/heif.rs
+++ b/src/heif.rs
@@ -104,6 +104,7 @@ impl LibHeif {
         decoding_options: Option<DecodingOptions>,
     ) -> Result<Image> {
         let decoding_options_ptr = decoding_options
+            .as_ref()
             .map(|o| o.inner)
             .unwrap_or_else(ptr::null_mut);
         let mut c_image: *mut lh::heif_image = ptr::null_mut();


### PR DESCRIPTION
- This caused the decoding options to not work as intended
- valgrind was unhappy

Without the as_ref(), the decoding_options gets dropped, dropping the allocated inner. Then the values inside become garbage, including `ignore_transformations`.

Note: there is no testing of this in the teste suite. I couldn't figure out how make a proper sample as merely changing the `orientation` with ExifTool isn't enough. If I figure it out, I can submit a PR testing `ignore_transformations`.